### PR TITLE
fix: Add override configuration for intune-agent timer

### DIFF
--- a/system_files/etc/systemd/user/intune-agent.timer.d/override.conf
+++ b/system_files/etc/systemd/user/intune-agent.timer.d/override.conf
@@ -1,0 +1,6 @@
+[Unit]
+PartOf=default.target
+After=default.target
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Fixes an issue where the service can't start due to the original target never being reached in a container